### PR TITLE
[packaging] BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/setup.changes
+++ b/setup.changes
@@ -1,3 +1,6 @@
+* Wed Oct 13 2021 Björn Bidar <bjorn.bidar@jolla.com> - 2.13.6+git5
+- [packaging] BuildRequire systemd via pkgconfig. JB#55010
+
 * Tue Mar 09 2021 Tomi Leppänen <tomi.leppanen@jolla.com> - 2.13.6+git4
 - Ensure that shells are listed in /etc/shells. Fixes JB#53402
 

--- a/setup.spec
+++ b/setup.spec
@@ -2,7 +2,7 @@
 
 Summary: A set of system configuration and setup files
 Name: setup
-Version: %{setup_version}+git4
+Version: %{setup_version}+git5
 Release: 1
 License: Public Domain
 URL: https://pagure.io/setup/
@@ -11,7 +11,8 @@ Patch0: setup-2.13.6-tcsh.patch
 Patch1: dont-use-here-string.patch
 BuildArch: noarch
 #systemd: required to use _tmpfilesdir macro
-BuildRequires: bash systemd
+BuildRequires: bash
+BuildRequires: pkgconfig(systemd)
 
 %description
 The setup package contains a set of important system configuration and


### PR DESCRIPTION
This allows to pick systemd-mini inside the builder instead of full
systemd.

Signed-off-by: Björn Bidar <bjorn.bidar@jolla.com>